### PR TITLE
init decoder builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,35 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2022-10-10
+
+### Fixed
+
+* Max length of encoded words [#1]
+* Manage tokens special chars [#3]
+
+### Changed
+
+* Refactored parser using chumsky [#7]
+
 ## [0.1.2] - 2020-12-30
 
 ### Fixed
 
-- Multiple encoded words separator
+* Multiple encoded words separator
 
 ## [0.1.1] - 2020-12-30
 
 ### Added
 
-- Evaluator with AST
+* Added evaluator with AST
 
 ### Changed
 
-- Decode fn accepts now `&[u8]` instead of `&str`
+* Decoded fn accepts now `&[u8]` instead of `&str`
 
 ### Fixed
 
-- Remove space between encoded words [#2]
+* Removed space between encoded words [#2]
 
 ## [0.1.0] - 2020-12-28
 
-### Added
+First official release.
 
-- Init repo
-
-[unreleased]: https://github.com/soywod/rfc2047-decoder/compare/v0.1.2...HEAD
+[unreleased]: https://github.com/soywod/rfc2047-decoder/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/soywod/rfc2047-decoder/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/soywod/rfc2047-decoder/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/soywod/rfc2047-decoder/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/soywod/rfc2047-decoder/releases/tag/v0.1.0
 
+[#1]: https://github.com/soywod/rfc2047-decoder/issues/1
 [#2]: https://github.com/soywod/rfc2047-decoder/issues/2
+[#3]: https://github.com/soywod/rfc2047-decoder/issues/3
+[#7]: https://github.com/soywod/rfc2047-decoder/issues/7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added decoder builder [#17](https://github.com/soywod/rfc2047-decoder/pull/17)
+
 ## [0.1.3] - 2022-10-10
 
 ### Fixed

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,0 +1,197 @@
+use std::result;
+use thiserror::Error;
+
+use crate::{evaluator, lexer, parser};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Lexer(#[from] lexer::Error),
+    #[error(transparent)]
+    Parser(#[from] parser::Error),
+    #[error(transparent)]
+    Evaluator(#[from] evaluator::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct Decoder {
+    pub skip_encoded_word_length: bool,
+}
+
+impl Decoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn skip_encoded_word_length(mut self, b: bool) -> Self {
+        self.skip_encoded_word_length = b;
+        self
+    }
+
+    pub fn decode<T: AsRef<[u8]>>(self, encoded_str: T) -> Result<String> {
+        let text_tokens = lexer::run(encoded_str.as_ref(), self)?;
+        let parsed_text = parser::run(text_tokens)?;
+        let evaluated_string = evaluator::run(parsed_text)?;
+
+        Ok(evaluated_string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Here are the main-tests which are listed here:
+    /// https://datatracker.ietf.org/doc/html/rfc2047#section-8
+    mod rfc_tests {
+        use crate::decode;
+
+        #[test]
+        fn test_example_1() {
+            assert_eq!(decode("=?ISO-8859-1?Q?a?=").unwrap(), "a");
+        }
+
+        #[test]
+        fn test_example_2() {
+            assert_eq!(decode("=?ISO-8859-1?Q?a?= b").unwrap(), "a b");
+        }
+
+        #[test]
+        fn test_example_3() {
+            assert_eq!(
+                decode("=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?=").unwrap(),
+                "ab"
+            );
+        }
+
+        #[test]
+        fn test_example_4() {
+            assert_eq!(
+                decode("=?ISO-8859-1?Q?a?=  =?ISO-8859-1?Q?b?=").unwrap(),
+                "ab"
+            );
+        }
+
+        #[test]
+        fn test_example_5() {
+            assert_eq!(
+                decode(
+                    "=?ISO-8859-1?Q?a?=               
+                     =?ISO-8859-1?Q?b?="
+                )
+                .unwrap(),
+                "ab"
+            );
+        }
+
+        #[test]
+        fn test_example_6() {
+            assert_eq!(decode("=?ISO-8859-1?Q?a_b?=").unwrap(), "a b");
+        }
+
+        #[test]
+        fn test_example_7() {
+            assert_eq!(
+                decode("=?ISO-8859-1?Q?a?= =?ISO-8859-2?Q?_b?=").unwrap(),
+                "a b"
+            );
+        }
+    }
+
+    /// Those are some custom tests
+    mod custom_tests {
+        use crate::{decode, Decoder};
+
+        #[test]
+        fn clear_empty() {
+            assert_eq!(decode("").unwrap(), "");
+        }
+
+        #[test]
+        fn clear_with_spaces() {
+            assert_eq!(decode("str with spaces").unwrap(), "str with spaces");
+        }
+
+        #[test]
+        fn utf8_qs_empty() {
+            assert_eq!(decode("").unwrap(), "");
+        }
+
+        #[test]
+        fn utf8_qs_with_str() {
+            assert_eq!(decode("=?UTF-8?Q?str?=").unwrap(), "str");
+        }
+
+        #[test]
+        fn utf8_qs_with_spaces() {
+            assert_eq!(
+                decode("=?utf8?q?str_with_spaces?=").unwrap(),
+                "str with spaces"
+            );
+        }
+
+        #[test]
+        fn utf8_qs_with_spec_chars() {
+            assert_eq!(
+                decode("=?utf8?q?str_with_special_=C3=A7h=C3=A0r=C3=9F?=").unwrap(),
+                "str with special çhàrß"
+            );
+        }
+
+        #[test]
+        fn utf8_qs_double() {
+            assert_eq!(
+                decode("=?UTF-8?Q?str?=\r\n =?UTF-8?Q?str?=").unwrap(),
+                "strstr"
+            );
+            assert_eq!(
+                decode("=?UTF-8?Q?str?=\n =?UTF-8?Q?str?=").unwrap(),
+                "strstr"
+            );
+            assert_eq!(decode("=?UTF-8?Q?str?= =?UTF-8?Q?str?=").unwrap(), "strstr");
+            assert_eq!(decode("=?UTF-8?Q?str?==?UTF-8?Q?str?=").unwrap(), "strstr");
+        }
+
+        #[test]
+        fn utf8_b64_empty() {
+            assert_eq!(decode("=?UTF-8?B??=").unwrap(), "");
+        }
+
+        #[test]
+        fn utf8_b64_with_str() {
+            assert_eq!(decode("=?UTF-8?B?c3Ry?=").unwrap(), "str");
+        }
+
+        #[test]
+        fn utf8_b64_with_spaces() {
+            assert_eq!(
+                decode("=?utf8?b?c3RyIHdpdGggc3BhY2Vz?=").unwrap(),
+                "str with spaces"
+            );
+        }
+
+        #[test]
+        fn utf8_b64_with_spec_chars() {
+            assert_eq!(
+                decode("=?utf8?b?c3RyIHdpdGggc3BlY2lhbCDDp2jDoHLDnw==?=").unwrap(),
+                "str with special çhàrß"
+            );
+        }
+
+        #[test]
+        fn utf8_b64_trailing_bit() {
+            assert_eq!(
+                decode("=?utf-8?B?UG9ydGFsZSBIYWNraW5nVGVhbW==?=").unwrap(),
+                "Portale HackingTeam",
+            );
+        }
+
+        #[test]
+        fn utf8_b64_skip_encoded_word_length() {
+            assert_eq!(
+                Decoder::new().skip_encoded_word_length(true).decode("=?utf-8?B?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?=").unwrap(),
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut interdum quam eu facilisis ornare.",
+            );
+        }
+    }
+}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -15,21 +15,30 @@ pub enum Error {
 
 pub type Result<T> = result::Result<T, Error>;
 
+/// Represents the decoder builder.
+///
+/// ```
+/// let decoder = Decoder::new().skip_encoded_word_length(true);
+/// let decoded_str = decoder.decode("=?UTF-8?B?c3Ry?=");
+/// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Decoder {
     pub skip_encoded_word_length: bool,
 }
 
 impl Decoder {
+    /// Creates a new decoder builder using default values.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets option to skip encoded word length verification.
     pub fn skip_encoded_word_length(mut self, b: bool) -> Self {
         self.skip_encoded_word_length = b;
         self
     }
 
+    /// Decodes the given RFC 2047 MIME Message Header encoded string.
     pub fn decode<T: AsRef<[u8]>>(self, encoded_str: T) -> Result<String> {
         let text_tokens = lexer::run(encoded_str.as_ref(), self)?;
         let parsed_text = parser::run(text_tokens)?;

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,21 +1,22 @@
+use base64::{CharacterSet, Config};
 use charset::Charset;
+use std::{result, string};
 
-use crate::parser::{Encoding, ParsedEncodedWord, ParsedEncodedWords, ClearText};
-
-pub type Result<T> = std::result::Result<T, Error>;
+use crate::parser::{ClearText, Encoding, ParsedEncodedWord, ParsedEncodedWords};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    DecodeUtf8(#[from] std::string::FromUtf8Error),
+    DecodeUtf8(#[from] string::FromUtf8Error),
     #[error(transparent)]
     DecodeBase64(#[from] base64::DecodeError),
     #[error(transparent)]
     DecodeQuotedPrintable(#[from] quoted_printable::QuotedPrintableError),
 }
 
+type Result<T> = result::Result<T, Error>;
+
 fn decode_base64(encoded_bytes: Vec<u8>) -> Result<Vec<u8>> {
-    let decoded_bytes = base64::decode(&encoded_bytes)?;
     let config = Config::new(CharacterSet::Standard, true).decode_allow_trailing_bits(true);
     let decoded_bytes = base64::decode_config(&encoded_bytes, config)?;
     Ok(decoded_bytes)
@@ -41,12 +42,10 @@ fn decode_with_encoding(encoding: Encoding, encoded_bytes: Vec<u8>) -> Result<Ve
     match encoding {
         Encoding::B => decode_base64(encoded_bytes),
         Encoding::Q => decode_quoted_printable(encoded_bytes),
-
     }
 }
 
 fn decode_with_charset(charset: Option<Charset>, decoded_bytes: Vec<u8>) -> Result<String> {
-
     let decoded_str = match charset {
         Some(charset) => charset.decode(&decoded_bytes).0,
         None => charset::decode_ascii(&decoded_bytes),
@@ -73,16 +72,14 @@ fn decode_parsed_encoded_word(
 pub fn run(parsed_encoded_words: ParsedEncodedWords) -> Result<String> {
     let message = parsed_encoded_words
         .into_iter()
-        .flat_map(
-            |parsed_encoded_word: ParsedEncodedWord| match parsed_encoded_word {
-                ParsedEncodedWord::ClearText(clear_text) => decode_utf8_string(clear_text),
-                ParsedEncodedWord::EncodedWord {
-                    charset,
-                    encoding,
-                    encoded_text,
-                } => decode_parsed_encoded_word(charset, encoding, encoded_text),
-            },
-        )
+        .flat_map(|parsed_encoded_word| match parsed_encoded_word {
+            ParsedEncodedWord::ClearText(clear_text) => decode_utf8_string(clear_text),
+            ParsedEncodedWord::EncodedWord {
+                charset,
+                encoding,
+                encoded_text,
+            } => decode_parsed_encoded_word(charset, encoding, encoded_text),
+        })
         .collect();
 
     Ok(message)

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -90,7 +90,7 @@ fn get_parser(decoder: Decoder) -> impl Parser<u8, Tokens, Error = Simple<u8>> {
     };
 
     let single_encoded_word = encoded_word_parser(&decoder);
-    let single_clear_text = clear_text_parser(decoder);
+    let single_clear_text = clear_text_parser(&decoder);
 
     encoded_words_in_a_row
         .or(single_encoded_word)
@@ -98,7 +98,7 @@ fn get_parser(decoder: Decoder) -> impl Parser<u8, Tokens, Error = Simple<u8>> {
         .repeated()
 }
 
-fn clear_text_parser(decoder: Decoder) -> impl Parser<u8, Token, Error = Simple<u8>> {
+fn clear_text_parser(decoder: &Decoder) -> impl Parser<u8, Token, Error = Simple<u8>> {
     use chumsky::prelude::*;
 
     const DEFAULT_EMPTY_INPUT_ERROR_MESSAGE: &str = "got empty input";

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,21 +1,24 @@
 use chumsky::{prelude::Simple, text::whitespace, Parser};
-use std::collections::HashSet;
+use std::{collections::HashSet, result};
+use thiserror::Error;
+
+use crate::Decoder;
+
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum Error {
+    #[error("Couldn't get tokens from: {:?}", .0)]
+    EncodingIssue(Vec<Simple<u8>>),
+    #[error("The encoded word is too long: {:?}", .0)]
+    EncodedWordTooLong(Vec<u8>),
+}
+
+type Result<T> = result::Result<T, Error>;
 
 const QUESTION_MARK: u8 = b'?';
 const SPACE: u8 = b' ';
 const AMOUNT_DELIMITERS: usize = "=????=".len();
 
-pub type Result<T> = std::result::Result<T, Error>;
 pub type Tokens = Vec<Token>;
-
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
-pub enum Error {
-    #[error("Couldn't get tokens from: {:?}", .0)]
-    EncodingIssue(Vec<Simple<u8>>),
-
-    #[error("The encoded word is too long: {:?}", .0)]
-    EncodedWordTooLong(Vec<u8>),
-}
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
 pub enum Token {
@@ -72,22 +75,22 @@ impl Token {
     }
 }
 
-pub fn run(encoded_bytes: &[u8]) -> Result<Tokens> {
-    let encoded_word = get_parser().parse(encoded_bytes);
-
+pub fn run(encoded_bytes: &[u8], decoder: Decoder) -> Result<Tokens> {
+    let encoded_word = get_parser(decoder).parse(encoded_bytes);
     encoded_word.map_err(Error::EncodingIssue)
 }
 
-fn get_parser() -> impl Parser<u8, Tokens, Error = Simple<u8>> {
+fn get_parser(decoder: Decoder) -> impl Parser<u8, Tokens, Error = Simple<u8>> {
     use chumsky::prelude::*;
 
     let encoded_words_in_a_row = {
-        let following_encoded_word = whitespace().ignore_then(encoded_word_parser().rewind());
-        encoded_word_parser().then_ignore(following_encoded_word)
+        let following_encoded_word =
+            whitespace().ignore_then(encoded_word_parser(&decoder).rewind());
+        encoded_word_parser(&decoder).then_ignore(following_encoded_word)
     };
 
-    let single_encoded_word = encoded_word_parser();
-    let single_clear_text = clear_text_parser();
+    let single_encoded_word = encoded_word_parser(&decoder);
+    let single_clear_text = clear_text_parser(decoder);
 
     encoded_words_in_a_row
         .or(single_encoded_word)
@@ -95,13 +98,13 @@ fn get_parser() -> impl Parser<u8, Tokens, Error = Simple<u8>> {
         .repeated()
 }
 
-fn clear_text_parser() -> impl Parser<u8, Token, Error = Simple<u8>> {
+fn clear_text_parser(decoder: Decoder) -> impl Parser<u8, Token, Error = Simple<u8>> {
     use chumsky::prelude::*;
 
     const DEFAULT_EMPTY_INPUT_ERROR_MESSAGE: &str = "got empty input";
 
-    take_until(encoded_word_parser().rewind().ignored().or(end())).try_map(
-        |(chars, ()): (Vec<u8>, ()), span| {
+    take_until(encoded_word_parser(&decoder).rewind().ignored().or(end())).try_map(
+        |(chars, ()), span| {
             if chars.is_empty() {
                 Err(Simple::custom(span, DEFAULT_EMPTY_INPUT_ERROR_MESSAGE))
             } else {
@@ -111,11 +114,13 @@ fn clear_text_parser() -> impl Parser<u8, Token, Error = Simple<u8>> {
     )
 }
 
-fn encoded_word_parser() -> impl Parser<u8, Token, Error = Simple<u8>> {
+fn encoded_word_parser(decoder: &Decoder) -> impl Parser<u8, Token, Error = Simple<u8>> {
     use chumsky::prelude::*;
 
-    let check_encoded_word_length = |token: Token, span| {
-        if token.len() > Token::MAX_ENCODED_WORD_LENGTH {
+    let skip_encoded_word_length = decoder.skip_encoded_word_length;
+
+    let check_encoded_word_length = move |token: Token, span| {
+        if !skip_encoded_word_length && token.len() > Token::MAX_ENCODED_WORD_LENGTH {
             Err(Simple::custom(
                 span,
                 Error::EncodedWordTooLong(token.get_bytes()),
@@ -151,14 +156,14 @@ fn get_especials() -> HashSet<u8> {
 
 #[cfg(test)]
 mod tests {
-    use crate::lexer::Token;
+    use crate::{lexer::Token, Decoder};
 
     use super::get_parser;
     use chumsky::Parser;
 
     #[test]
     fn test_encoded_word() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         let message = "=?ISO-8859-1?Q?Yeet?=".as_bytes();
 
         let parsed = parser.parse(message).unwrap();
@@ -175,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_clear_text() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         let message = "I use Arch by the way".as_bytes();
 
         let parsed = parser.parse(message).unwrap();
@@ -192,7 +197,7 @@ mod tests {
     // https://datatracker.ietf.org/doc/html/rfc2047#section-8
     #[test]
     fn test_encoded_from_1() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         let message = "=?ISO-8859-1?Q?a?=".as_bytes();
 
         let parsed = parser.parse(message).unwrap();
@@ -210,7 +215,7 @@ mod tests {
     // see test_encoded_from_1
     #[test]
     fn test_encoded_from_2() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         let message = "=?ISO-8859-1?Q?a?= b".as_bytes();
 
         let parsed = parser.parse(message).unwrap();
@@ -231,7 +236,7 @@ mod tests {
     // see test_encoded_from_1
     #[test]
     fn test_encoded_from_3() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         let message = "=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?=".as_bytes();
 
         let parsed = parser.parse(message).unwrap();
@@ -257,7 +262,7 @@ mod tests {
     /// See: https://datatracker.ietf.org/doc/html/rfc2047#section-8
     #[test]
     fn test_multiple_encoded_words() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         let message = "=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?= =?ISO-8859-1?Q?c?=".as_bytes();
 
         let parsed = parser.parse(message).unwrap();
@@ -286,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_ignore_mutiple_spaces_between_encoded_words() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         let message =
             "=?ISO-8859-1?Q?a?=                               =?ISO-8859-1?Q?b?=".as_bytes();
 
@@ -312,7 +317,7 @@ mod tests {
     /// An encoded word with more then 75 chars should be parsed as a normal cleartext
     #[test]
     fn test_too_long_encoded_word() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         // "=?" (2) + "ISO-8859-1" (10) + "?" (1) + "Q" (1) + "?" (1) + 'a' (60) + "?=" (2)
         // = 2 + 10 + 1 + 1 + 1 + 60 + 2
         // = 77 => too long
@@ -326,7 +331,7 @@ mod tests {
 
     #[test]
     fn test_encoded_word_has_especials() {
-        let parser = get_parser();
+        let parser = get_parser(Decoder::new());
         let message = "=?ISO-8859-1(?Q?a?=".as_bytes();
         let parsed = parser.parse(message).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,19 +7,8 @@ mod evaluator;
 mod lexer;
 mod parser;
 
-/// Decodes a RFC 2047 MIME Message Header.
-///
-/// ```
-/// fn main() {
-///     match rfc2047_decoder::decode("=?utf8?q?str_with_spaces?=".as_bytes()) {
-///         Ok(s) => println!("{}", s),
-///         Err(err) => panic!(err),
-///     }
-/// }
-/// ```
-///
-/// The function can return an error if the lexer, the parser or the
-/// evaluator encounters an error.
+/// Decodes the given RFC 2047 MIME Message Header encoded string
+/// using a default decoder.
 pub fn decode<T: AsRef<[u8]>>(encoded_str: T) -> decoder::Result<String> {
     Decoder::new().decode(encoded_str)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,13 @@
 #![doc(html_root_url = "https://docs.rs/rfc2047-decoder/0.1.3")]
 
+pub mod decoder;
+pub use decoder::Decoder;
+
 mod evaluator;
 mod lexer;
 mod parser;
 
-pub type Result<T> = std::result::Result<T, Error>;
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error(transparent)]
-    Lexer(#[from] lexer::Error),
-    #[error(transparent)]
-    Parser(#[from] parser::Error),
-    #[error(transparent)]
-    Evaluate(#[from] evaluator::Error),
-}
-
-/// Decode a RFC 2047 MIME Message Header.
+/// Decodes a RFC 2047 MIME Message Header.
 ///
 /// ```
 /// fn main() {
@@ -27,164 +18,8 @@ pub enum Error {
 /// }
 /// ```
 ///
-/// # Errors
-///
-/// The function can return an error if the lexer,
-/// the parser or the evaluator encounters an error.
-pub fn decode<T: AsRef<[u8]>>(encoded_str: T) -> Result<String> {
-    let text_tokens: lexer::Tokens = lexer::run(encoded_str.as_ref())?;
-    let parsed_text: parser::ParsedEncodedWords = parser::run(text_tokens)?;
-    let evaluated_string: String = evaluator::run(parsed_text)?;
-
-    Ok(evaluated_string)
-}
-
-#[cfg(test)]
-mod tests {
-
-    /// Here are the main-tests which are listed here:
-    /// https://datatracker.ietf.org/doc/html/rfc2047#section-8
-    mod rfc_tests {
-        use crate::decode;
-
-        #[test]
-        fn test_example_1() {
-            assert_eq!(decode("=?ISO-8859-1?Q?a?=").unwrap(), "a");
-        }
-
-        #[test]
-        fn test_example_2() {
-            assert_eq!(decode("=?ISO-8859-1?Q?a?= b").unwrap(), "a b");
-        }
-
-        #[test]
-        fn test_example_3() {
-            assert_eq!(
-                decode("=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?=").unwrap(),
-                "ab"
-            );
-        }
-
-        #[test]
-        fn test_example_4() {
-            assert_eq!(
-                decode("=?ISO-8859-1?Q?a?=  =?ISO-8859-1?Q?b?=").unwrap(),
-                "ab"
-            );
-        }
-
-        #[test]
-        fn test_example_5() {
-            assert_eq!(
-                decode(
-                    "=?ISO-8859-1?Q?a?=               
-                          =?ISO-8859-1?Q?b?="
-                )
-                .unwrap(),
-                "ab"
-            );
-        }
-
-        #[test]
-        fn test_example_6() {
-            assert_eq!(decode("=?ISO-8859-1?Q?a_b?=").unwrap(), "a b");
-        }
-
-        #[test]
-        fn test_example_7() {
-            assert_eq!(
-                decode("=?ISO-8859-1?Q?a?= =?ISO-8859-2?Q?_b?=").unwrap(),
-                "a b"
-            );
-        }
-    }
-
-    /// Those are some custom tests
-    mod custom_tests {
-        use crate::decode;
-
-        #[test]
-        fn clear_empty() {
-            assert_eq!(decode("").unwrap(), "");
-        }
-
-        #[test]
-        fn clear_with_spaces() {
-            assert_eq!(decode("str with spaces").unwrap(), "str with spaces");
-        }
-
-        #[test]
-        fn utf8_qs_empty() {
-            assert_eq!(decode("").unwrap(), "");
-        }
-
-        #[test]
-        fn utf8_qs_with_str() {
-            assert_eq!(decode("=?UTF-8?Q?str?=").unwrap(), "str");
-        }
-
-        #[test]
-        fn utf8_qs_with_spaces() {
-            assert_eq!(
-                decode("=?utf8?q?str_with_spaces?=").unwrap(),
-                "str with spaces"
-            );
-        }
-
-        #[test]
-        fn utf8_qs_with_spec_chars() {
-            assert_eq!(
-                decode("=?utf8?q?str_with_special_=C3=A7h=C3=A0r=C3=9F?=").unwrap(),
-                "str with special çhàrß"
-            );
-        }
-
-        #[test]
-        fn utf8_qs_double() {
-            assert_eq!(
-                decode("=?UTF-8?Q?str?=\r\n =?UTF-8?Q?str?=").unwrap(),
-                "strstr"
-            );
-            assert_eq!(
-                decode("=?UTF-8?Q?str?=\n =?UTF-8?Q?str?=").unwrap(),
-                "strstr"
-            );
-            assert_eq!(decode("=?UTF-8?Q?str?= =?UTF-8?Q?str?=").unwrap(), "strstr");
-            assert_eq!(decode("=?UTF-8?Q?str?==?UTF-8?Q?str?=").unwrap(), "strstr");
-        }
-
-        #[test]
-        fn utf8_b64_empty() {
-            assert_eq!(decode("=?UTF-8?B??=").unwrap(), "");
-        }
-
-        #[test]
-        fn utf8_b64_with_str() {
-            assert_eq!(decode("=?UTF-8?B?c3Ry?=").unwrap(), "str");
-        }
-
-        #[test]
-        fn utf8_b64_with_spaces() {
-            assert_eq!(
-                decode("=?utf8?b?c3RyIHdpdGggc3BhY2Vz?=").unwrap(),
-                "str with spaces"
-            );
-        }
-
-        #[test]
-        fn utf8_b64_with_spec_chars() {
-            assert_eq!(
-                decode("=?utf8?b?c3RyIHdpdGggc3BlY2lhbCDDp2jDoHLDnw==?=").unwrap(),
-                "str with special çhàrß"
-            );
-        }
-
-        #[test]
-        fn utf8_b64_trailing_bit() {
-            assert_ok(
-                "Portale HackingTeam",
-                "=?utf-8?B?UG9ydGFsZSBIYWNraW5nVGVhbW==?=",
-            );
-        }
-    }
+/// The function can return an error if the lexer, the parser or the
+/// evaluator encounters an error.
+pub fn decode<T: AsRef<[u8]>>(encoded_str: T) -> decoder::Result<String> {
+    Decoder::new().decode(encoded_str)
 }


### PR DESCRIPTION
@TornaxO7 I initiated the decoder builder, which allow you to decode with options. Everything from the `lib.rs` moved to a new file `decoder.rs`. Now the `lib.rs` only exposes the `decode` function which has the same behaviour as before except that it uses the decoder builder behind the scene. I just added one option `skip_encoded_word_length` which skips the encoded word length check and allow decoding strings bigger than 76 chars. I will merge straight so I can release a new version for Himalaya, but feel free to comment below if you have any remark or suggestion!

---

It is the first time I dive into the code since your refactor with chumsky and I'm really impressed, it looks way better and more robust, well done :muscle: 