### PR TITLE
Fix too long encoded word

### DIFF
--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -13,7 +13,7 @@ fn main() {
     // using the decoder builder (custom options)
     assert_eq!(
         rfc2047_decoder::Decoder::new()
-            .skip_encoded_word_length(true)
+            .too_long_encoded_word_strategy(rfc2047_decoder::RecoverStrategy::Skip)
             .decode(encoded_str.as_bytes())
             .unwrap(),
         decoded_str

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -129,7 +129,7 @@ mod tests {
 
     /// Those are some custom tests
     mod custom_tests {
-        use crate::{decode, Decoder};
+        use crate::{decode, decoder::RecoverStrategy, Decoder};
 
         #[test]
         fn clear_empty() {
@@ -218,7 +218,7 @@ mod tests {
         #[test]
         fn utf8_b64_skip_encoded_word_length() {
             assert_eq!(
-                Decoder::new().skip_encoded_word_length(true).decode("=?utf-8?B?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?=").unwrap(),
+                Decoder::new().too_long_encoded_word_strategy(RecoverStrategy::Skip).decode("=?utf-8?B?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?=").unwrap(),
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut interdum quam eu facilisis ornare.",
             );
         }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -24,10 +24,21 @@ pub enum Error {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RecoverStrategy {
     /// Decode the encoded word although it's incorrectly encoded.
+    ///
+    /// # Example
+    /// Take a look to [Decoder#RecoveryStrategy::Decode](Decoder#recoverstrategydecode).
     Decode,
+
     /// Skip the incorrectly encoded encoded word.
+    ///
+    /// # Example
+    /// Take a look to [Decoder#RecoveryStrategy::Skip](Decoder#recoverstrategyskip).
     Skip,
+
     /// Abort the string-parsing and return an error.
+    ///
+    /// # Example
+    /// Take a look to [Decoder#RecoveryStrategy::Abort](Decoder#recoverstrategyabort-default).
     Abort,
 }
 
@@ -151,17 +162,17 @@ mod tests {
         use crate::decode;
 
         #[test]
-        fn test_example_1() {
+        fn example_1() {
             assert_eq!(decode("=?ISO-8859-1?Q?a?=").unwrap(), "a");
         }
 
         #[test]
-        fn test_example_2() {
+        fn example_2() {
             assert_eq!(decode("=?ISO-8859-1?Q?a?= b").unwrap(), "a b");
         }
 
         #[test]
-        fn test_example_3() {
+        fn example_3() {
             assert_eq!(
                 decode("=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?=").unwrap(),
                 "ab"
@@ -169,7 +180,7 @@ mod tests {
         }
 
         #[test]
-        fn test_example_4() {
+        fn example_4() {
             assert_eq!(
                 decode("=?ISO-8859-1?Q?a?=  =?ISO-8859-1?Q?b?=").unwrap(),
                 "ab"
@@ -177,7 +188,7 @@ mod tests {
         }
 
         #[test]
-        fn test_example_5() {
+        fn example_5() {
             assert_eq!(
                 decode(
                     "=?ISO-8859-1?Q?a?=               
@@ -189,12 +200,12 @@ mod tests {
         }
 
         #[test]
-        fn test_example_6() {
+        fn example_6() {
             assert_eq!(decode("=?ISO-8859-1?Q?a_b?=").unwrap(), "a b");
         }
 
         #[test]
-        fn test_example_7() {
+        fn example_7() {
             assert_eq!(
                 decode("=?ISO-8859-1?Q?a?= =?ISO-8859-2?Q?_b?=").unwrap(),
                 "a b"
@@ -204,7 +215,7 @@ mod tests {
 
     /// Those are some custom tests
     mod custom_tests {
-        use crate::{decode, decoder::RecoverStrategy, Decoder};
+        use crate::decode;
 
         #[test]
         fn clear_empty() {
@@ -287,14 +298,6 @@ mod tests {
             assert_eq!(
                 decode("=?utf-8?B?UG9ydGFsZSBIYWNraW5nVGVhbW==?=").unwrap(),
                 "Portale HackingTeam",
-            );
-        }
-
-        #[test]
-        fn utf8_b64_skip_encoded_word_length() {
-            assert_eq!(
-                Decoder::new().too_long_encoded_word_strategy(RecoverStrategy::Skip).decode("=?utf-8?B?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?=").unwrap(),
-                "=?utf-8?B?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?=",
             );
         }
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -158,6 +158,7 @@ impl Default for Decoder {
 mod tests {
     /// Here are the main-tests which are listed here:
     /// https://datatracker.ietf.org/doc/html/rfc2047#section-8
+    /// Scroll down until you see the table.
     mod rfc_tests {
         use crate::decode;
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -33,9 +33,9 @@ pub type Result<T> = result::Result<T, Error>;
 /// let decoder = rfc2047_decoder::Decoder::new().skip_encoded_word_length(true);
 /// let decoded_str = decoder.decode("=?UTF-8?B?c3Ry?=");
 /// ```
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Decoder {
-    pub skip_encoded_word_length: bool,
+    pub too_long_encoded_word: RecoverStrategy,
 }
 
 impl Decoder {
@@ -44,9 +44,9 @@ impl Decoder {
         Self::default()
     }
 
-    /// Sets option to skip encoded word length verification.
-    pub fn skip_encoded_word_length(mut self, b: bool) -> Self {
-        self.skip_encoded_word_length = b;
+    /// Set the strategy if the decoder finds an encoded word which is too long.
+    pub fn too_long_encoded_word_strategy(mut self, strategy: RecoverStrategy) -> Self {
+        self.too_long_encoded_word = strategy;
         self
     }
 
@@ -57,6 +57,14 @@ impl Decoder {
         let evaluated_string = evaluator::run(parsed_text)?;
 
         Ok(evaluated_string)
+    }
+}
+
+impl Default for Decoder {
+    fn default() -> Self {
+        Self {
+            too_long_encoded_word: RecoverStrategy::Abort,
+        }
     }
 }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -8,15 +8,15 @@ use crate::{evaluator, lexer, parser};
 pub enum Error {
     /// Symbolises that an error occured in the lexer.
     #[error(transparent)]
-    Lexer(#[from] lexer::LexerError),
+    Lexer(#[from] lexer::Error),
 
     /// Symbolises that an error occured in the parser.
     #[error(transparent)]
-    Parser(#[from] parser::ParserError),
+    Parser(#[from] parser::Error),
 
     /// Symbolises that an error occured in the evaluator.
     #[error(transparent)]
-    Evaluator(#[from] evaluator::EvaluatorError),
+    Evaluator(#[from] evaluator::Error),
 }
 
 /// Determines which strategy should be used if an encoded word isn't encoded as

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -30,7 +30,10 @@ pub type Result<T> = result::Result<T, Error>;
 /// Represents the decoder builder.
 ///
 /// ```
-/// let decoder = rfc2047_decoder::Decoder::new().skip_encoded_word_length(true);
+/// use rfc2047_decoder::{Decoder, RecoverStrategy};
+///
+/// let decoder = Decoder::new()
+///                 .too_long_encoded_word_strategy(RecoverStrategy::Skip);
 /// let decoded_str = decoder.decode("=?UTF-8?B?c3Ry?=");
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -219,7 +222,7 @@ mod tests {
         fn utf8_b64_skip_encoded_word_length() {
             assert_eq!(
                 Decoder::new().too_long_encoded_word_strategy(RecoverStrategy::Skip).decode("=?utf-8?B?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?=").unwrap(),
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut interdum quam eu facilisis ornare.",
+                "=?utf-8?B?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?=",
             );
         }
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -162,17 +162,17 @@ mod tests {
         use crate::decode;
 
         #[test]
-        fn example_1() {
+        fn decode_encoded_word_single_char() {
             assert_eq!(decode("=?ISO-8859-1?Q?a?=").unwrap(), "a");
         }
 
         #[test]
-        fn example_2() {
+        fn decode_encoded_word_separated_by_whitespace() {
             assert_eq!(decode("=?ISO-8859-1?Q?a?= b").unwrap(), "a b");
         }
 
         #[test]
-        fn example_3() {
+        fn decode_two_encoded_chars() {
             assert_eq!(
                 decode("=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?=").unwrap(),
                 "ab"
@@ -180,7 +180,7 @@ mod tests {
         }
 
         #[test]
-        fn example_4() {
+        fn whitespace_between_two_encoded_words_should_be_ignored() {
             assert_eq!(
                 decode("=?ISO-8859-1?Q?a?=  =?ISO-8859-1?Q?b?=").unwrap(),
                 "ab"
@@ -188,7 +188,7 @@ mod tests {
         }
 
         #[test]
-        fn example_5() {
+        fn whitespace_chars_between_two_encoded_words_should_be_ignored() {
             assert_eq!(
                 decode(
                     "=?ISO-8859-1?Q?a?=               
@@ -200,12 +200,12 @@ mod tests {
         }
 
         #[test]
-        fn example_6() {
+        fn whitespace_encoded_in_encoded_word() {
             assert_eq!(decode("=?ISO-8859-1?Q?a_b?=").unwrap(), "a b");
         }
 
         #[test]
-        fn example_7() {
+        fn ignore_whitespace_between_two_encoded_words_but_not_the_encoded_whitespace() {
             assert_eq!(
                 decode("=?ISO-8859-1?Q?a?= =?ISO-8859-2?Q?_b?=").unwrap(),
                 "a b"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -15,7 +15,7 @@ pub enum Error {
 
 /// Determines which strategy should be used if an encoded word isn't encoded as
 /// described in the RFC.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RecoverStrategy {
     /// Decode the encoded word although it's incorrectly encoded.
     Decode,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -13,6 +13,18 @@ pub enum Error {
     Evaluator(#[from] evaluator::Error),
 }
 
+/// Determines which strategy should be used if an encoded word isn't encoded as
+/// described in the RFC.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RecoverStrategy {
+    /// Decode the encoded word although it's incorrectly encoded.
+    Decode,
+    /// Skip the incorrectly encoded encoded word.
+    Skip,
+    /// Abort the string-parsing and return an error.
+    Abort,
+}
+
 pub type Result<T> = result::Result<T, Error>;
 
 /// Represents the decoder builder.

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 
 use crate::parser::{ClearText, Encoding, ParsedEncodedWord, ParsedEncodedWords};
 
-#[derive(Error, Debug)]
-pub enum Error {
+#[derive(Error, Debug, PartialEq)]
+pub enum EvaluatorError {
     #[error(transparent)]
     DecodeUtf8Error(#[from] string::FromUtf8Error),
     #[error(transparent)]
@@ -15,7 +15,7 @@ pub enum Error {
     DecodeQuotedPrintableError(#[from] quoted_printable::QuotedPrintableError),
 }
 
-type Result<T> = result::Result<T, Error>;
+type Result<T> = result::Result<T, EvaluatorError>;
 
 fn decode_base64(encoded_bytes: Vec<u8>) -> Result<Vec<u8>> {
     let config = Config::new(CharacterSet::Standard, true).decode_allow_trailing_bits(true);

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 use crate::parser::{ClearText, Encoding, ParsedEncodedWord, ParsedEncodedWords};
 
+/// All errors which the evaluator can throw.
 #[derive(Error, Debug, PartialEq)]
 pub enum EvaluatorError {
     #[error(transparent)]

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -10,7 +10,7 @@ use crate::parser::{ClearText, Encoding, ParsedEncodedWord, ParsedEncodedWords};
 
 /// All errors which the evaluator can throw.
 #[derive(Error, Debug, PartialEq)]
-pub enum EvaluatorError {
+pub enum Error {
     #[error(transparent)]
     DecodeUtf8Error(#[from] string::FromUtf8Error),
     #[error(transparent)]
@@ -19,7 +19,7 @@ pub enum EvaluatorError {
     DecodeQuotedPrintableError(#[from] quoted_printable::QuotedPrintableError),
 }
 
-type Result<T> = result::Result<T, EvaluatorError>;
+type Result<T> = result::Result<T, Error>;
 
 fn decode_base64(encoded_bytes: Vec<u8>) -> Result<Vec<u8>> {
     let base64_decoder = {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -20,7 +20,7 @@ type Result<T> = result::Result<T, EvaluatorError>;
 
 fn decode_base64(encoded_bytes: Vec<u8>) -> Result<Vec<u8>> {
     let config = Config::new(CharacterSet::Standard, true).decode_allow_trailing_bits(true);
-    let decoded_bytes = base64::decode_config(&encoded_bytes, config)?;
+    let decoded_bytes = base64::decode_config(encoded_bytes, config)?;
     Ok(decoded_bytes)
 }
 

--- a/src/lexer/encoded_word.rs
+++ b/src/lexer/encoded_word.rs
@@ -2,8 +2,8 @@ use std::fmt::Display;
 
 use super::QUESTION_MARK;
 
-pub const PREFIX: &'static [u8] = "=?".as_bytes();
-pub const SUFFIX: &'static [u8] = "?=".as_bytes();
+pub const PREFIX: &[u8] = "=?".as_bytes();
+pub const SUFFIX: &[u8] = "?=".as_bytes();
 pub const MAX_LENGTH: usize = 75;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/lexer/encoded_word.rs
+++ b/src/lexer/encoded_word.rs
@@ -1,0 +1,63 @@
+use std::fmt::Display;
+
+use super::QUESTION_MARK;
+
+pub const PREFIX: &'static [u8] = "=?".as_bytes();
+pub const SUFFIX: &'static [u8] = "?=".as_bytes();
+pub const MAX_LENGTH: usize = 75;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EncodedWord {
+    pub charset: Vec<u8>,
+    pub encoding: Vec<u8>,
+    pub encoded_text: Vec<u8>,
+}
+
+impl EncodedWord {
+    pub fn new(charset: Vec<u8>, encoding: Vec<u8>, encoded_text: Vec<u8>) -> Self {
+        Self {
+            charset,
+            encoding,
+            encoded_text,
+        }
+    }
+
+    pub fn from_parser(((charset, encoding), encoded_text): ((Vec<u8>, Vec<u8>), Vec<u8>)) -> Self {
+        Self::new(charset, encoding, encoded_text)
+    }
+
+    /// Returns the amount of `char`s for this encoded word
+    pub fn len(&self) -> usize {
+        self.get_bytes(true).len()
+    }
+
+    pub fn get_bytes(&self, with_delimiters: bool) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        if with_delimiters {
+            bytes.extend(PREFIX);
+            bytes.extend(&self.charset);
+            bytes.extend(&[QUESTION_MARK]);
+            bytes.extend(&self.encoding);
+            bytes.extend(&[QUESTION_MARK]);
+            bytes.extend(&self.encoded_text);
+            bytes.extend(SUFFIX);
+        } else {
+            bytes.extend(&self.charset);
+            bytes.extend(&self.encoding);
+            bytes.extend(&self.encoded_text);
+        }
+
+        bytes
+    }
+}
+
+impl Display for EncodedWord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let charset = String::from_utf8(self.charset.clone()).unwrap();
+        let encoding = String::from_utf8(self.encoded_text.clone()).unwrap();
+        let encoded_text = String::from_utf8(self.encoding.clone()).unwrap();
+
+        write!(f, "=?{}?{}?{}?=", charset, encoding, encoded_text)
+    }
+}

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -40,14 +40,14 @@ impl Display for TooLongEncodedWords {
 
 /// All errors which the lexer can throw.
 #[derive(Error, Debug, Clone, PartialEq)]
-pub enum LexerError {
+pub enum Error {
     #[error("cannot parse bytes into tokens")]
     ParseBytesError(Vec<Simple<u8>>),
     #[error("Cannot parse the following encoded words, because they are too long: {0}")]
     ParseEncodedWordTooLongError(TooLongEncodedWords),
 }
 
-type Result<T> = result::Result<T, LexerError>;
+type Result<T> = result::Result<T, Error>;
 
 pub type Tokens = Vec<Token>;
 
@@ -70,7 +70,7 @@ impl Token {
 pub fn run(encoded_bytes: &[u8], decoder: Decoder) -> Result<Tokens> {
     let tokens = get_parser(&decoder)
         .parse(encoded_bytes)
-        .map_err(LexerError::ParseBytesError)?;
+        .map_err(Error::ParseBytesError)?;
 
     validate_tokens(tokens, &decoder)
 }
@@ -150,7 +150,7 @@ fn get_especials() -> HashSet<u8> {
 
 fn validate_tokens(tokens: Tokens, decoder: &Decoder) -> Result<Tokens> {
     if let Some(too_long_encoded_words) = get_too_long_encoded_words(&tokens, decoder) {
-        return Err(LexerError::ParseEncodedWordTooLongError(too_long_encoded_words));
+        return Err(Error::ParseEncodedWordTooLongError(too_long_encoded_words));
     }
 
     Ok(tokens)
@@ -182,7 +182,7 @@ mod tests {
         Decoder,
     };
 
-    use super::{get_parser, LexerError, TooLongEncodedWords};
+    use super::{get_parser, Error, TooLongEncodedWords};
     use chumsky::Parser;
 
     #[test]
@@ -351,7 +351,7 @@ mod tests {
 
         assert_eq!(
             parsed,
-            Err(LexerError::ParseEncodedWordTooLongError(
+            Err(Error::ParseEncodedWordTooLongError(
                 TooLongEncodedWords::new(vec![EncodedWord {
                     charset: "ISO-8859-1".as_bytes().to_vec(),
                     encoding: "Q".as_bytes().to_vec(),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -186,7 +186,7 @@ mod tests {
     use chumsky::Parser;
 
     #[test]
-    fn test_encoded_word() {
+    fn encoded_word() {
         let parser = get_parser(&Decoder::new());
         let message = "=?ISO-8859-1?Q?Yeet?=".as_bytes();
 
@@ -203,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_text() {
+    fn clear_text() {
         let parser = get_parser(&Decoder::new());
         let message = "I use Arch by the way".as_bytes();
 
@@ -220,7 +220,7 @@ mod tests {
     // The following examples are from the encoded-form table in section 8:
     // https://datatracker.ietf.org/doc/html/rfc2047#section-8
     #[test]
-    fn test_encoded_from_1() {
+    fn encoded_from_1() {
         let parser = get_parser(&Decoder::new());
         let message = "=?ISO-8859-1?Q?a?=".as_bytes();
 
@@ -236,9 +236,9 @@ mod tests {
         );
     }
 
-    // see test_encoded_from_1
+    // see encoded_from_1
     #[test]
-    fn test_encoded_from_2() {
+    fn encoded_from_2() {
         let parser = get_parser(&Decoder::new());
         let message = "=?ISO-8859-1?Q?a?= b".as_bytes();
 
@@ -257,9 +257,9 @@ mod tests {
         );
     }
 
-    // see test_encoded_from_1
+    // see encoded_from_1
     #[test]
-    fn test_encoded_from_3() {
+    fn encoded_from_3() {
         let parser = get_parser(&Decoder::new());
         let message = "=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?=".as_bytes();
 
@@ -285,7 +285,7 @@ mod tests {
     /// Test if parser can parse multiple encoded words in a row
     /// See: https://datatracker.ietf.org/doc/html/rfc2047#section-8
     #[test]
-    fn test_multiple_encoded_words() {
+    fn multiple_encoded_words() {
         let parser = get_parser(&Decoder::new());
         let message = "=?ISO-8859-1?Q?a?= =?ISO-8859-1?Q?b?= =?ISO-8859-1?Q?c?=".as_bytes();
 
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ignore_mutiple_spaces_between_encoded_words() {
+    fn ignore_mutiple_spaces_between_encoded_words() {
         let parser = get_parser(&Decoder::new());
         let message =
             "=?ISO-8859-1?Q?a?=                               =?ISO-8859-1?Q?b?=".as_bytes();
@@ -365,7 +365,7 @@ mod tests {
     }
 
     #[test]
-    fn test_encoded_word_has_especials() {
+    fn encoded_word_has_especials() {
         let parser = get_parser(&Decoder::new());
         let message = "=?ISO-8859-1(?Q?a?=".as_bytes();
         let parsed = parser.parse(message).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,18 @@
 #![doc(html_root_url = "https://docs.rs/rfc2047-decoder/0.2.1")]
 
 mod decoder;
-pub use decoder::{Decoder, RecoverStrategy, Error, Result};
+pub use decoder::{Decoder, RecoverStrategy, Error};
 
 mod evaluator;
 mod lexer;
 mod parser;
 
+pub use lexer::{TooLongEncodedWords, LexerError};
+pub use parser::ParserError;
+pub use evaluator::EvaluatorError;
+
 /// Decodes the given RFC 2047 MIME Message Header encoded string
 /// using a default decoder.
-pub fn decode<T: AsRef<[u8]>>(encoded_str: T) -> Result<String> {
+pub fn decode<T: AsRef<[u8]>>(encoded_str: T) -> Result<String, Error> {
     Decoder::new().decode(encoded_str)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ mod evaluator;
 mod lexer;
 mod parser;
 
-pub use lexer::{TooLongEncodedWords, LexerError};
-pub use parser::ParserError;
-pub use evaluator::EvaluatorError;
+pub use lexer::{TooLongEncodedWords, Error as LexerError};
+pub use parser::Error as ParserError;
+pub use evaluator::Error as EvaluatorError;
 
 /// Decodes the given RFC 2047 MIME Message Header encoded string
 /// using a default decoder.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/rfc2047-decoder/0.2.1")]
 
 mod decoder;
-pub use decoder::{Decoder, Error, Result};
+pub use decoder::{Decoder, RecoverStrategy, Error, Result};
 
 mod evaluator;
 mod lexer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,18 +7,6 @@ mod evaluator;
 mod lexer;
 mod parser;
 
-/// Determines which strategy should be used if an encoded word isn't encoded as
-/// described in the RFC.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum RecoverStrategy {
-    /// Decode the encoded word although it's incorrectly encoded.
-    Decode,
-    /// Skip the incorrectly encoded encoded word.
-    Skip,
-    /// Abort the string-parsing and return an error.
-    Abort,
-}
-
 /// Decodes the given RFC 2047 MIME Message Header encoded string
 /// using a default decoder.
 pub fn decode<T: AsRef<[u8]>>(encoded_str: T) -> Result<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,18 @@ mod evaluator;
 mod lexer;
 mod parser;
 
+/// Determines which strategy should be used if an encoded word isn't encoded as
+/// described in the RFC.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RecoverStrategy {
+    /// Decode the encoded word although it's incorrectly encoded.
+    Decode,
+    /// Skip the incorrectly encoded encoded word.
+    Skip,
+    /// Abort the string-parsing and return an error.
+    Abort,
+}
+
 /// Decodes the given RFC 2047 MIME Message Header encoded string
 /// using a default decoder.
 pub fn decode<T: AsRef<[u8]>>(encoded_str: T) -> Result<String> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use crate::lexer::{Token, Tokens, encoded_word};
 
 /// All errors which the parser can throw.
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
-pub enum ParserError {
+pub enum Error {
     #[error("cannot parse encoding: encoding is bigger than a char")]
     ParseEncodingTooBigError,
     #[error("cannot parse encoding: encoding is empty")]
@@ -14,7 +14,7 @@ pub enum ParserError {
     ParseEncodingError(char),
 }
 
-type Result<T> = result::Result<T, ParserError>;
+type Result<T> = result::Result<T, Error>;
 
 pub type ClearText = Vec<u8>;
 pub type ParsedEncodedWords = Vec<ParsedEncodedWord>;
@@ -32,20 +32,20 @@ impl Encoding {
 }
 
 impl TryFrom<Vec<u8>> for Encoding {
-    type Error = ParserError;
+    type Error = Error;
 
     fn try_from(token: Vec<u8>) -> Result<Self> {
         if token.len() > Self::MAX_LENGTH {
-            return Err(ParserError::ParseEncodingTooBigError);
+            return Err(Error::ParseEncodingTooBigError);
         }
 
-        let encoding = token.first().ok_or(ParserError::ParseEncodingEmptyError)?;
+        let encoding = token.first().ok_or(Error::ParseEncodingEmptyError)?;
         let encoding = *encoding as char;
 
         match encoding.to_ascii_lowercase() {
             Encoding::Q_CHAR => Ok(Self::Q),
             Encoding::B_CHAR => Ok(Self::B),
-            _ => Err(ParserError::ParseEncodingError(encoding)),
+            _ => Err(Error::ParseEncodingError(encoding)),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use charset::Charset;
 use std::{convert::TryFrom, result};
 
-use crate::lexer::{Token, Tokens};
+use crate::lexer::{Token, Tokens, encoded_word};
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
@@ -60,18 +60,14 @@ pub enum ParsedEncodedWord {
 }
 
 impl ParsedEncodedWord {
-    pub fn convert_encoded_word(
-        charset: Vec<u8>,
-        encoding: Vec<u8>,
-        encoded_text: Vec<u8>,
-    ) -> Result<Self> {
-        let encoding = Encoding::try_from(encoding)?;
-        let charset = Charset::for_label(&charset);
+    pub fn convert_encoded_word(encoded_word: encoded_word::EncodedWord) -> Result<Self> {
+        let encoding = Encoding::try_from(encoded_word.encoding)?;
+        let charset = Charset::for_label(&encoded_word.charset);
 
         Ok(Self::EncodedWord {
             charset,
             encoding,
-            encoded_text,
+            encoded_text: encoded_word.encoded_text,
         })
     }
 }
@@ -86,11 +82,7 @@ fn convert_tokens_to_encoded_words(tokens: Tokens) -> Result<ParsedEncodedWords>
         .into_iter()
         .map(|token: Token| match token {
             Token::ClearText(clear_text) => Ok(ParsedEncodedWord::ClearText(clear_text)),
-            Token::EncodedWord {
-                charset,
-                encoding,
-                encoded_text,
-            } => ParsedEncodedWord::convert_encoded_word(charset, encoding, encoded_text),
+            Token::EncodedWord(encoded_word) => ParsedEncodedWord::convert_encoded_word(encoded_word),
         })
         .collect()
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,8 +3,8 @@ use std::{convert::TryFrom, result};
 
 use crate::lexer::{Token, Tokens, encoded_word};
 
-#[derive(thiserror::Error, Debug, Clone)]
-pub enum Error {
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+pub enum ParserError {
     #[error("cannot parse encoding: encoding is bigger than a char")]
     ParseEncodingTooBigError,
     #[error("cannot parse encoding: encoding is empty")]
@@ -13,7 +13,7 @@ pub enum Error {
     ParseEncodingError(char),
 }
 
-type Result<T> = result::Result<T, Error>;
+type Result<T> = result::Result<T, ParserError>;
 
 pub type ClearText = Vec<u8>;
 pub type ParsedEncodedWords = Vec<ParsedEncodedWord>;
@@ -31,20 +31,20 @@ impl Encoding {
 }
 
 impl TryFrom<Vec<u8>> for Encoding {
-    type Error = Error;
+    type Error = ParserError;
 
     fn try_from(token: Vec<u8>) -> Result<Self> {
         if token.len() > Self::MAX_LENGTH {
-            return Err(Error::ParseEncodingTooBigError);
+            return Err(ParserError::ParseEncodingTooBigError);
         }
 
-        let encoding = token.first().ok_or(Error::ParseEncodingEmptyError)?;
+        let encoding = token.first().ok_or(ParserError::ParseEncodingEmptyError)?;
         let encoding = *encoding as char;
 
         match encoding.to_ascii_lowercase() {
             Encoding::Q_CHAR => Ok(Self::Q),
             Encoding::B_CHAR => Ok(Self::B),
-            _ => Err(Error::ParseEncodingError(encoding)),
+            _ => Err(ParserError::ParseEncodingError(encoding)),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@ use std::{convert::TryFrom, result};
 
 use crate::lexer::{Token, Tokens, encoded_word};
 
+/// All errors which the parser can throw.
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum ParserError {
     #[error("cannot parse encoding: encoding is bigger than a char")]


### PR DESCRIPTION
This PR should fix https://github.com/soywod/rfc2047-decoder/issues/29

- This PR also adds more docs of the API
- There are some breaking changes in the API, for example the way how you set the parser-behaviour if it encounts an invalid encoded-word.
- You can now decide, how the parser should behave if an encoded word is incorrectly written:
  - Abort (the lexer will return an `Err`)
  - Decode (the lexer will just decode as if it would be a valid encoded word)
  - Skip (the lexer will treat it as a clear text)

