### PR TITLE
Improve doc + bugfix (v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2023-09-17
+- extending docs about some structs
+- fixing `Display` implementation of `TooLongEncodedWord`
+
 ## [1.0.0] - 2023-09-16
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rfc2047-decoder"
 description = "Rust library for decoding RFC 2047 MIME Message Headers."
-version = "1.0.0" # do not forget html_root_url
+version = "1.0.1" # do not forget html_root_url
 authors = ["soywod <clement.douin@posteo.net>", "TornaxO7 <tornax07@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/soywod/rfc2047-decoder"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -162,7 +162,7 @@ mod tests {
     /// https://datatracker.ietf.org/doc/html/rfc2047#section-8
     /// Scroll down until you see the table.
     mod rfc_tests {
-        use crate::{decode, LexerError};
+        use crate::decode;
 
         #[test]
         fn decode_encoded_word_single_char() {
@@ -218,7 +218,7 @@ mod tests {
 
     /// Those are some custom tests
     mod custom_tests {
-        use crate::{decode, LexerError};
+        use crate::decode;
 
         #[test]
         fn clear_empty() {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -52,7 +52,9 @@ type Result<T> = result::Result<T, Error>;
 ///
 /// let decoder = Decoder::new()
 ///                 .too_long_encoded_word_strategy(RecoverStrategy::Skip);
-/// let decoded_str = decoder.decode("=?UTF-8?B?c3Ry?=");
+/// let decoded_str = decoder.decode("=?UTF-8?B?c3Ry?=").unwrap();
+///
+/// assert_eq!(decoded_str, "str");
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Decoder {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -128,7 +128,7 @@ impl Decoder {
     ///
     /// let parsed = decoder.decode(message);
     ///
-    /// assert_eq!(parsed, Err(Lexer(ParseEncodedWordTooLongError(TooLongEncodedWords(vec!["=?utf-8?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?B?=".to_string()])))));
+    /// assert_eq!(parsed, Err(Lexer(ParseEncodedWordTooLongError(TooLongEncodedWords(vec!["=?utf-8?B?TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gVXQgaW50ZXJkdW0gcXVhbSBldSBmYWNpbGlzaXMgb3JuYXJlLg==?=".to_string()])))));
     /// ```
     pub fn too_long_encoded_word_strategy(mut self, strategy: RecoverStrategy) -> Self {
         self.too_long_encoded_word = strategy;
@@ -162,7 +162,7 @@ mod tests {
     /// https://datatracker.ietf.org/doc/html/rfc2047#section-8
     /// Scroll down until you see the table.
     mod rfc_tests {
-        use crate::decode;
+        use crate::{decode, LexerError};
 
         #[test]
         fn decode_encoded_word_single_char() {
@@ -218,7 +218,7 @@ mod tests {
 
     /// Those are some custom tests
     mod custom_tests {
-        use crate::decode;
+        use crate::{decode, LexerError};
 
         #[test]
         fn clear_empty() {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,6 +1,7 @@
 use base64::{
     alphabet,
-    engine::{GeneralPurpose, GeneralPurposeConfig}, Engine,
+    engine::{GeneralPurpose, GeneralPurposeConfig},
+    Engine,
 };
 use charset::Charset;
 use std::{result, string};

--- a/src/lexer/encoded_word.rs
+++ b/src/lexer/encoded_word.rs
@@ -55,8 +55,8 @@ impl EncodedWord {
 impl Display for EncodedWord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let charset = String::from_utf8(self.charset.clone()).unwrap();
-        let encoding = String::from_utf8(self.encoded_text.clone()).unwrap();
-        let encoded_text = String::from_utf8(self.encoding.clone()).unwrap();
+        let encoding = String::from_utf8(self.encoding.clone()).unwrap();
+        let encoded_text = String::from_utf8(self.encoded_text.clone()).unwrap();
 
         write!(f, "=?{}?{}?{}?=", charset, encoding, encoded_text)
     }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -13,6 +13,27 @@ const SPACE: u8 = b' ';
 
 /// A helper struct which implements [std::fmt::Display] for `Vec<String>` and
 /// which contains the encoded words which are too long as a `String`.
+///
+/// # Example
+/// ```
+/// use rfc2047_decoder::{self, decode, RecoverStrategy, LexerError};
+///
+/// // the first string and the third string are more than 75 characters, hence
+/// // they are actually invalid encoded words
+/// let message = concat![
+///     "=?utf-8?B?bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb==?=",
+///     "among us",
+///     "=?utf-8?B?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==?=",
+/// ];
+
+/// let result = decode(message).unwrap_err();
+/// if let rfc2047_decoder::Error::Lexer(LexerError::ParseEncodedWordTooLongError(invalid_encoded_words)) = result {
+///     assert_eq!(invalid_encoded_words.0[0], "=?utf-8?B?bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb==?=");
+///     assert_eq!(invalid_encoded_words.0[1], "=?utf-8?B?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==?=");
+/// } else {
+///     assert!(false);
+/// }
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TooLongEncodedWords(pub Vec<String>);
 
@@ -178,7 +199,7 @@ fn get_too_long_encoded_words(tokens: &Tokens, decoder: &Decoder) -> Option<TooL
 #[cfg(test)]
 mod tests {
     use crate::{
-        lexer::{encoded_word::EncodedWord, Token, run},
+        lexer::{encoded_word::EncodedWord, run, Token},
         Decoder,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,15 +10,15 @@
 //! to use this crate.
 
 mod decoder;
-pub use decoder::{Decoder, RecoverStrategy, Error};
+pub use decoder::{Decoder, Error, RecoverStrategy};
 
 mod evaluator;
 mod lexer;
 mod parser;
 
-pub use lexer::{TooLongEncodedWords, Error as LexerError};
-pub use parser::Error as ParserError;
 pub use evaluator::Error as EvaluatorError;
+pub use lexer::{Error as LexerError, TooLongEncodedWords};
+pub use parser::Error as ParserError;
 
 /// Decodes the given RFC 2047 MIME Message Header encoded string
 /// using a default decoder.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/rfc2047-decoder/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/rfc2047-decoder/1.0.1")]
 //! # Introduction
 //! This crate provides a [Decoder] and the function [decode], in order to
 //! encoded words as described in the [RFC 2047].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,13 @@
 #![doc(html_root_url = "https://docs.rs/rfc2047-decoder/1.0.0")]
+//! # Introduction
+//! This crate provides a [Decoder] and the function [decode], in order to
+//! encoded words as described in the [RFC 2047].
+//!
+//! [RFC 2047]: https://datatracker.ietf.org/doc/html/rfc2047
+//!
+//! # Where to look
+//! You will likely want to start looking into [Decoder] and/or the [decode]
+//! to use this crate.
 
 mod decoder;
 pub use decoder::{Decoder, RecoverStrategy, Error};
@@ -13,6 +22,22 @@ pub use evaluator::Error as EvaluatorError;
 
 /// Decodes the given RFC 2047 MIME Message Header encoded string
 /// using a default decoder.
+///
+/// This function equals doing `Decoder::new().decode`.
+///
+/// # Example
+/// ```
+/// use rfc2047_decoder::{decode, Decoder};
+///
+/// let encoded_message = "=?ISO-8859-1?Q?hello_there?=".as_bytes();
+/// let decoded_message = "hello there";
+///
+/// // This ...
+/// assert_eq!(decode(encoded_message).unwrap(), decoded_message);
+///
+/// // ... equals this:
+/// assert_eq!(Decoder::new().decode(encoded_message).unwrap(), decoded_message);
+/// ```
 pub fn decode<T: AsRef<[u8]>>(encoded_str: T) -> Result<String, Error> {
     Decoder::new().decode(encoded_str)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use charset::Charset;
 use std::{convert::TryFrom, result};
 
-use crate::lexer::{Token, Tokens, encoded_word};
+use crate::lexer::{encoded_word, Token, Tokens};
 
 /// All errors which the parser can throw.
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
@@ -83,7 +83,9 @@ fn convert_tokens_to_encoded_words(tokens: Tokens) -> Result<ParsedEncodedWords>
         .into_iter()
         .map(|token: Token| match token {
             Token::ClearText(clear_text) => Ok(ParsedEncodedWord::ClearText(clear_text)),
-            Token::EncodedWord(encoded_word) => ParsedEncodedWord::convert_encoded_word(encoded_word),
+            Token::EncodedWord(encoded_word) => {
+                ParsedEncodedWord::convert_encoded_word(encoded_word)
+            }
         })
         .collect()
 }


### PR DESCRIPTION
- improves doc
- There's a mistake [here](https://github.com/soywod/rfc2047-decoder/blob/master/src/lexer/encoded_word.rs#L58-L59): (encoding contains the encoded text and the encoded text contains the encoding) this is fixed now with this PR